### PR TITLE
Deeplink update testing

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -37,9 +37,52 @@
                 <data android:scheme="snappybirds" android:host="demo" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".GlobalLeaderBoardActivityKt"
+            android:configChanges="keyboardHidden|orientation"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:windowSoftInputMode="stateHidden">
+            <intent-filter
+                android:autoVerify="true"
+                >
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="snapyrtest.app" />
+                <data android:pathPrefix="/leader-board" />
+                <data android:scheme="https" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".NewsFeedActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+            android:windowSoftInputMode="adjustResize|stateUnchanged">
+            <intent-filter
+                android:autoVerify="true"
+                >
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:host="snapyrtest.app" />
+                <data android:pathPrefix="/home-screen" />
+                <data android:scheme="https" />
+            </intent-filter>
+        </activity>
+
         <!-- Used by Snapyr to automatically track notification receipt/interaction -->
         <activity android:name="com.snapyr.sdk.notifications.SnapyrNotificationListener"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.snapyr.sdk.notifications.TRACK_BROADCAST" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.snapyr.sdk.android:snapyr:1.+'
+    implementation 'com.snapyr.sdk.android:snapyr:1.2.2-beta6'
 
     // additional dependencies required by Snapyr
     implementation('androidx.lifecycle:lifecycle-process:2.2.0')

--- a/app/res/layout/activity_global_leaderboard.xml
+++ b/app/res/layout/activity_global_leaderboard.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:context="com.snapyr.flappybird.GlobalLeaderBoardActivityKt">
+
+        <TextView
+            android:id="@+id/activity_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:textSize="40dp"
+            android:text="Global Leaderboard" />
+
+        <TextView
+            android:id="@+id/activity_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:text="@string/standard_activity_description" />
+
+        <Button
+            android:id="@+id/action_track_a_leaderboard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pushtest_leaderboard" />
+
+        <TextView
+            android:id="@+id/event_log"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:textSize="16dp"
+            android:bufferType="editable" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/res/layout/activity_newsfeed.xml
+++ b/app/res/layout/activity_newsfeed.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:context="com.snapyr.flappybird.NewsFeedActivity">
+
+        <TextView
+            android:id="@+id/activity_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:textSize="40dp"
+            android:text="News Feed" />
+
+        <TextView
+            android:id="@+id/activity_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:text="@string/singletask_description" />
+
+        <Button
+            android:id="@+id/action_track_a_newsfeed"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pushtest_homescreen" />
+
+        <TextView
+            android:id="@+id/event_log"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:textSize="16dp"
+            android:bufferType="editable" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/res/layout/activity_splash.xml
+++ b/app/res/layout/activity_splash.xml
@@ -80,6 +80,31 @@
                     android:layout_alignParentTop="true"
                     android:text="Initialize Snapyr" />
 
+                <Button
+                    android:id="@+id/pushtest_bad_url"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/pushtest_bad_url" />
+
+                <Button
+                    android:id="@+id/pushtest_leaderboard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pushtest_leaderboard" />
+
+                <Button
+                    android:id="@+id/pushtest_homescreen"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pushtest_homescreen" />
+
+                <Button
+                    android:id="@+id/pushtest_no_deeplink"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pushtest_no_deeplink" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/res/layout/activity_splash.xml
+++ b/app/res/layout/activity_splash.xml
@@ -88,16 +88,16 @@
                     android:text="@string/pushtest_bad_url" />
 
                 <Button
-                    android:id="@+id/pushtest_leaderboard"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/pushtest_leaderboard" />
-
-                <Button
                     android:id="@+id/pushtest_homescreen"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/pushtest_homescreen" />
+
+                <Button
+                    android:id="@+id/pushtest_leaderboard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pushtest_leaderboard" />
 
                 <Button
                     android:id="@+id/pushtest_no_deeplink"

--- a/app/res/layout/activity_splash.xml
+++ b/app/res/layout/activity_splash.xml
@@ -15,25 +15,45 @@
             android:id="@+id/topBanner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             tools:ignore="WebViewLayout" />
-        
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <EditText
-                    android:id="@+id/identify_key"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentTop="true"
-                    android:layout_weight="0.55"
-                    android:hint="SDK Write Key"
+                    android:orientation="horizontal"
+                    android:weightSum="1">
 
-                    />
+                    <TextView
+                        android:id="@+id/current_env"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:layout_weight="0"
+                        android:gravity="center_vertical"
+                        android:paddingRight="8dp"
+                        android:text="Env:"
+                        android:textColor="@android:color/black" />
+
+                    <EditText
+                        android:id="@+id/identify_key"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:layout_weight="1"
+                        android:enabled="false"
+                        android:hint="SDK Write Key"
+                        android:textSize="14dp" />
+                </LinearLayout>
+
 
                 <EditText
                     android:id="@+id/identify_userid"
@@ -66,44 +86,75 @@
                     android:layout_weight="0.55"
                     android:hint="Phone" />
 
-                <Button
-                    android:id="@+id/env"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentTop="true"
-                    android:text="Env" />
+                    android:orientation="horizontal"
+                    android:weightSum="1">
 
-                <Button
-                    android:id="@+id/initSnapyrButton"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentTop="true"
-                    android:text="Initialize Snapyr" />
+                    <Button
+                        android:id="@+id/doIdentifyButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:layout_weight="0.5"
+                        android:text="Identify" />
 
-                <Button
-                    android:id="@+id/pushtest_bad_url"
+                    <Button
+                        android:id="@+id/changeEnvOrKey"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:layout_weight="0.5"
+                        android:text="Change SDK Key + Env" />
+                </LinearLayout>
+
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="@string/pushtest_bad_url" />
+                    android:orientation="horizontal"
+                    android:weightSum="1">
 
-                <Button
-                    android:id="@+id/pushtest_homescreen"
+                    <Button
+                        android:id="@+id/pushtest_bad_url"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.5"
+                        android:text="@string/pushtest_bad_url"
+                        android:textSize="13dp" />
+
+                    <Button
+                        android:id="@+id/pushtest_homescreen"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.5"
+                        android:text="@string/pushtest_homescreen"
+                        android:textSize="13dp" />
+                </LinearLayout>
+
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/pushtest_homescreen" />
+                    android:orientation="horizontal"
+                    android:weightSum="1">
 
-                <Button
-                    android:id="@+id/pushtest_leaderboard"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/pushtest_leaderboard" />
+                    <Button
+                        android:id="@+id/pushtest_leaderboard"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.5"
+                        android:text="@string/pushtest_leaderboard"
+                        android:textSize="13dp" />
 
-                <Button
-                    android:id="@+id/pushtest_no_deeplink"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/pushtest_no_deeplink" />
+                    <Button
+                        android:id="@+id/pushtest_no_deeplink"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0.5"
+                        android:text="@string/pushtest_no_deeplink"
+                        android:textSize="13dp" />
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -115,17 +166,17 @@
                     <Button
                         android:id="@+id/playerStinksButton"
                         android:layout_width="match_parent"
-                        android:layout_weight="0.5"
                         android:layout_height="wrap_content"
                         android:layout_alignParentTop="true"
+                        android:layout_weight="0.5"
                         android:text="Player Stinks event" />
 
                     <Button
                         android:id="@+id/reachedVipButton"
                         android:layout_width="match_parent"
-                        android:layout_weight="0.5"
                         android:layout_height="wrap_content"
                         android:layout_alignParentTop="true"
+                        android:layout_weight="0.5"
                         android:text="Reached VIP event" />
 
                 </LinearLayout>
@@ -149,9 +200,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
+                    android:bufferType="editable"
                     android:paddingLeft="8dp"
-                    android:textSize="16dp"
-                    android:bufferType="editable" />
+                    android:textSize="16dp" />
 
             </LinearLayout>
 

--- a/app/res/layout/activity_splash.xml
+++ b/app/res/layout/activity_splash.xml
@@ -16,99 +16,121 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:ignore="WebViewLayout" />
-
-        <EditText
-            android:id="@+id/identify_key"
+        
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_weight="0.55"
-            android:hint="SDK Write Key"
-
-            />
-
-        <EditText
-            android:id="@+id/identify_userid"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_weight="0.55"
-
-            android:hint="User Id" />
-
-        <EditText
-            android:id="@+id/identify_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_weight="0.55"
-            android:hint="Name" />
-
-        <EditText
-            android:id="@+id/identify_email"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="0.55"
-            android:hint="Email" />
-
-        <EditText
-            android:id="@+id/identify_phone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="0.55"
-            android:hint="Phone" />
-
-        <Button
-            android:id="@+id/env"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:text="Env" />
-
-        <Button
-            android:id="@+id/initSnapyrButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:text="Initialize Snapyr" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:weightSum="1">
-
-            <Button
-                android:id="@+id/playerStinksButton"
+            android:layout_height="wrap_content">
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_weight="0.5"
                 android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:text="Player Stinks event" />
+                android:orientation="vertical">
 
-            <Button
-                android:id="@+id/reachedVipButton"
-                android:layout_width="match_parent"
-                android:layout_weight="0.5"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:text="Reached VIP event" />
+                <EditText
+                    android:id="@+id/identify_key"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_weight="0.55"
+                    android:hint="SDK Write Key"
 
-        </LinearLayout>
+                    />
 
-        <Button
-            android:id="@+id/playButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:layout_marginTop="16dp"
-            android:text="Play" />
+                <EditText
+                    android:id="@+id/identify_userid"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_weight="0.55"
 
-        <WebView
-            android:id="@+id/bottomBanner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:ignore="WebViewLayout" />
+                    android:hint="User Id" />
+
+                <EditText
+                    android:id="@+id/identify_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_weight="0.55"
+                    android:hint="Name" />
+
+                <EditText
+                    android:id="@+id/identify_email"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.55"
+                    android:hint="Email" />
+
+                <EditText
+                    android:id="@+id/identify_phone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.55"
+                    android:hint="Phone" />
+
+                <Button
+                    android:id="@+id/env"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:text="Env" />
+
+                <Button
+                    android:id="@+id/initSnapyrButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:text="Initialize Snapyr" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:orientation="horizontal"
+                    android:weightSum="1">
+
+                    <Button
+                        android:id="@+id/playerStinksButton"
+                        android:layout_width="match_parent"
+                        android:layout_weight="0.5"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:text="Player Stinks event" />
+
+                    <Button
+                        android:id="@+id/reachedVipButton"
+                        android:layout_width="match_parent"
+                        android:layout_weight="0.5"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentTop="true"
+                        android:text="Reached VIP event" />
+
+                </LinearLayout>
+
+                <Button
+                    android:id="@+id/playButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginTop="16dp"
+                    android:text="Play" />
+
+                <WebView
+                    android:id="@+id/bottomBanner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:ignore="WebViewLayout" />
+
+                <TextView
+                    android:id="@+id/event_log"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:paddingLeft="8dp"
+                    android:textSize="16dp"
+                    android:bufferType="editable" />
+
+            </LinearLayout>
+
+        </ScrollView>
 
     </LinearLayout>
 

--- a/app/res/layout/alert_writekey_env.xml
+++ b/app/res/layout/alert_writekey_env.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/alert_sdk_writekey"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:hint="SDK Write Key"
+        android:textSize="16dp" />
+
+    <TextView
+        android:id="@+id/alert_env"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:paddingLeft="8dp"
+        android:text="Env: "
+        android:textAlignment="center"
+        android:textSize="16dp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:orientation="horizontal"
+        android:weightSum="1">
+
+        <Button
+            android:id="@+id/alert_env_dev"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.333"
+            android:text="dev" />
+
+        <Button
+            android:id="@+id/alert_env_stage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.334"
+            android:text="stage" />
+
+        <Button
+            android:id="@+id/alert_env_prod"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.333"
+            android:text="prod" />
+    </LinearLayout>
+
+</LinearLayout>
+

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Flappy Bird</string>
+
+    <string name="pushtest_bad_url">birdsPushTestBadUrl</string>
+    <string name="pushtest_leaderboard">birdsPushTestLeaderboard</string>
+    <string name="pushtest_homescreen">birdsPushTestHomescreen</string>
+    <string name="pushtest_no_deeplink">birdsPushTestNoDeeplink</string>
+
+    <string name="singletask_description">This is a <b><u>singleTask</u></b> activity.
+        Consecutive deep links should keep the same activity and trigger
+        <b>onNewIntent()</b> and <b>onResume()</b>.
+    </string>
+    <string name="standard_activity_description">This is a <b><u>standard</u></b> activity.
+        Consecutive deep links should each open a new activity instance and trigger
+        <b>onCreate()</b>, <b>onStart()</b>, and <b>onResume()</b>.
+    </string>
 </resources>

--- a/app/src/com/snapyr/flappybird/DebugActivityBase.kt
+++ b/app/src/com/snapyr/flappybird/DebugActivityBase.kt
@@ -1,0 +1,112 @@
+package com.snapyr.flappybird
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.text.Html
+import android.text.Spanned
+import android.util.Log
+import android.widget.TextView
+import android.widget.Toast
+import com.snapyr.sdk.Snapyr
+import java.text.MessageFormat
+import java.text.SimpleDateFormat
+import java.util.*
+
+abstract class DebugActivityBase: Activity() {
+    var isNewActivity = true
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Log.w("SnapyrFlappy", MessageFormat.format("$localClassName: onCreate: {0}", intent))
+    }
+
+    // Wait til onPostCreate for first `addLog` call as it depends on the view being ready, which was probably set up during onCreate
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+        val intent = intent
+        this.addLog("onPostCreate", "intent: $intent")
+        intent?.let { handleOpenIntent(it) }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        Log.w("SnapyrFlappy", MessageFormat.format("$localClassName: onStart: {0}", intent))
+    }
+
+    override fun onResume() {
+        Log.w("SnapyrFlappy", "$localClassName: onResume")
+        super.onResume()
+        if (!isNewActivity) {
+            this.addLog("Activity resumed")
+        }
+        isNewActivity = false
+    }
+
+    override fun onNewIntent(newIntent: Intent) {
+        Log.w("SnapyrFlappy", "$localClassName: onNewIntent: $newIntent")
+        addLog("onNewIntent", MessageFormat.format("intent: {0}", newIntent))
+        handleOpenIntent(newIntent)
+        // `onNewIntent` doesn't automatically update the intent on the activity. Do that explicitly
+        // so any later activity calls to `getIntent()` get this new version
+        this.intent = newIntent
+        super.onNewIntent(newIntent)
+    }
+
+    fun handleOpenIntent(intent: Intent) {
+        val action = intent.action
+        val data = intent.data
+        if (data == null) {
+            Toast.makeText(this, "No deep link info provided", Toast.LENGTH_LONG).show()
+            return
+        }
+        val paths = data.pathSegments
+        if (paths.size > 1) {
+            val response = paths[0]
+            val text = paths[1]
+            Toast.makeText(this, text, Toast.LENGTH_LONG).show()
+            Log.e("SnapyrFlappy", "$localClassName open intent data: $data")
+        }
+    }
+
+    protected fun safeTrack(event: String) {
+        try {
+            Snapyr.with(this).track(event)
+        } catch (e: Exception) {
+            Toast.makeText(this, "Error running track - did you forget to initialize Snapyr?", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    protected fun addLog(name: String) {
+        val formatter = SimpleDateFormat("HH:mm:ss.SSS")
+        val date = Date()
+        val newEntry =
+            Html.fromHtml(String.format("<p>%s: <b>%s</b></p>", formatter.format(date), name))
+        prependLogEntry(newEntry)
+    }
+
+    protected fun addLog(name: String, description: String) {
+        val formatter = SimpleDateFormat("HH:mm:ss.SSS")
+        val date = Date()
+        val newEntry = Html.fromHtml(
+            String.format(
+                "<p>%s: <b>%s</b>: %s</p>",
+                formatter.format(date), name, description
+            )
+        )
+        prependLogEntry(newEntry)
+    }
+
+    protected fun prependLogEntry(newEntry: Spanned) {
+        val logView = findViewById<TextView>(R.id.event_log)
+        Log.i("SnapyrFlappy", newEntry.toString())
+        if (logView == null) {
+            Log.e("SnapyrFlappy", "$localClassName: addLog: could not find event_log view")
+            return
+        }
+        // Prepend so the latest entry shows up on top
+        val editableText = logView.editableText
+        editableText.insert(0, newEntry)
+        logView.text = editableText
+    }
+}

--- a/app/src/com/snapyr/flappybird/GlobalLeaderBoardActivityKt.kt
+++ b/app/src/com/snapyr/flappybird/GlobalLeaderBoardActivityKt.kt
@@ -1,0 +1,21 @@
+package com.snapyr.flappybird
+
+import android.os.Bundle
+import android.view.View
+import kotlinx.android.synthetic.main.activity_global_leaderboard.*
+
+class GlobalLeaderBoardActivityKt : DebugActivityBase() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_global_leaderboard)
+
+        action_track_a_leaderboard.setOnClickListener {
+            onButtonAClicked(it)
+        }
+    }
+
+    private fun onButtonAClicked(v: View) {
+        safeTrack("birdsPushTestLeaderboard")
+    }
+}

--- a/app/src/com/snapyr/flappybird/MyApp.kt
+++ b/app/src/com/snapyr/flappybird/MyApp.kt
@@ -3,16 +3,22 @@ package com.snapyr.flappybird
 import android.app.Application
 import android.content.Context
 import android.preference.PreferenceManager
+import android.util.Log
 
 class MyApp: Application() {
     override fun onCreate() {
         super.onCreate()
-        val prefs1 = PreferenceManager.getDefaultSharedPreferences(this)
-        val editor = prefs1.edit()
-        editor.clear()
-        editor.commit()
+
+        Log.e("SnapyrFlappy", "APPLICATION onCreate")
 
         MyApp.appContext = applicationContext
+
+        var snapyrHelper = SnapyrComponent.build(this.applicationContext)
+        // Reset SDK (clear user id / batch queue) if env or write key were changed prior to this run
+        if (SnapyrData.instance.needsReset) {
+            snapyrHelper.onDoReset()
+            SnapyrData.instance.needsReset = false
+        }
     }
 
     companion object {

--- a/app/src/com/snapyr/flappybird/NewsFeedActivity.kt
+++ b/app/src/com/snapyr/flappybird/NewsFeedActivity.kt
@@ -1,0 +1,22 @@
+package com.snapyr.flappybird
+
+import android.os.Bundle
+import android.view.View
+import kotlinx.android.synthetic.main.activity_newsfeed.*
+
+class NewsFeedActivity : DebugActivityBase() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_newsfeed)
+
+
+        action_track_a_newsfeed.setOnClickListener {
+            onButtonAClicked(it)
+        }
+    }
+
+    private fun onButtonAClicked(v: View) {
+        safeTrack("birdsPushTestHomescreen")
+    }
+}

--- a/app/src/com/snapyr/flappybird/SnapyrComponent.kt
+++ b/app/src/com/snapyr/flappybird/SnapyrComponent.kt
@@ -35,6 +35,9 @@ class SnapyrComponent private constructor(private val context: Context) {
     companion object {
         private var ourInstance: SnapyrComponent? = null
 
+        val hasInstance: Boolean
+            get() = ourInstance != null
+
         val instance: SnapyrComponent
             get() {
                 synchronized(SnapyrComponent) {
@@ -57,19 +60,20 @@ class SnapyrComponent private constructor(private val context: Context) {
                 if (ourInstance!!.snapyrData.env == "stg")
                     snapyr.enableStageEnvironment()
                 snapyr.enableSnapyrPushHandling()
-                        .trackApplicationLifecycleEvents() // Enable this to record certain application events automatically
-                        .recordScreenViews() // Enable this to record screen views automatically
-                        .flushQueueSize(1)
-                        .configureInAppHandling(
-                                InAppConfig()
-                                        .setPollingRate(30000)
-                                        .setActionCallback { inAppMessage: InAppMessage? ->
-                                            if (inAppMessage != null) {
-                                                ourInstance!!.userInAppCallback(
-                                                        inAppMessage
-                                                )
-                                            }
-                                        })
+                    .logLevel(Snapyr.LogLevel.VERBOSE)
+                    .trackApplicationLifecycleEvents() // Enable this to record certain application events automatically
+                    .recordScreenViews() // Enable this to record screen views automatically
+                    .flushQueueSize(1)
+                    .configureInAppHandling(
+                        InAppConfig()
+                            .setPollingRate(30000)
+                            .setActionCallback { inAppMessage: InAppMessage? ->
+                                if (inAppMessage != null) {
+                                    ourInstance!!.userInAppCallback(
+                                        inAppMessage
+                                    )
+                                }
+                            })
                 ;
                 val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                 if (!prefs.getBoolean("firstTime", false)) {

--- a/app/src/com/snapyr/flappybird/SnapyrComponent.kt
+++ b/app/src/com/snapyr/flappybird/SnapyrComponent.kt
@@ -53,7 +53,7 @@ class SnapyrComponent private constructor(private val context: Context) {
                 if (ourInstance == null) {
                     ourInstance = SnapyrComponent(context)
                 }
-                var snapyr = Snapyr.Builder(context, SnapyrData.instance.identifyKey)
+                var snapyr = Snapyr.Builder(context, SnapyrData.instance.sdkWriteKey)
                 Log.d("SnapyrFlappy", "singleton.env: " + ourInstance!!.snapyrData.env);
                 if (ourInstance!!.snapyrData.env == "dev")
                     snapyr.enableDevEnvironment()
@@ -75,16 +75,11 @@ class SnapyrComponent private constructor(private val context: Context) {
                                 }
                             })
                 ;
-                val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-                if (!prefs.getBoolean("firstTime", false)) {
-
-                    if (!Snapyr.Valid())
-                        Snapyr.setSingletonInstance(snapyr.build());
-                    val editor = prefs.edit()
-                    editor.putBoolean("firstTime", true)
-                    editor.putBoolean("register", false)
-                    editor.commit()
+                if (!Snapyr.Valid()) {
+                    Snapyr.setSingletonInstance(snapyr.build());
+                    Log.d("SnapyrFlappy", "Snapyr SDK initialized.")
                 }
+
                 return ourInstance!!
             }
         }

--- a/app/src/com/snapyr/flappybird/SnapyrData.kt
+++ b/app/src/com/snapyr/flappybird/SnapyrData.kt
@@ -27,7 +27,7 @@ class SnapyrData private constructor(val context: Context) {
                 prefEditor.putString("env", value)
                 prefEditor.apply()
             }
-        var identifyKey: String = preferences.getString("identifyKey", "")!!
+        var sdkWriteKey: String = preferences.getString("identifyKey", "")!!
             set(value) {
                 field = value
                 prefEditor.putString("identifyKey", value)
@@ -55,6 +55,12 @@ class SnapyrData private constructor(val context: Context) {
             set(value) {
                 field = value
                 prefEditor.putString("identifyPhone", value)
+                prefEditor.apply()
+            }
+        var needsReset: Boolean = preferences.getBoolean("needsReset", false)
+            set(value) {
+                field = value
+                prefEditor.putBoolean("needsReset", value)
                 prefEditor.apply()
             }
 }

--- a/app/src/com/snapyr/flappybird/SplashActivity.kt
+++ b/app/src/com/snapyr/flappybird/SplashActivity.kt
@@ -24,11 +24,14 @@ import android.util.Base64
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Button
 import android.widget.EditText
-import android.widget.Toast
+import android.widget.TextView
 import com.github.kostasdrakonakis.androidnavigator.IntentNavigator
 import com.snapyr.sdk.Properties
 import com.snapyr.sdk.Snapyr
@@ -52,50 +55,30 @@ class SplashActivity : DebugActivityBase(), InAppCallback {
     private lateinit var identifyName: EditText
     private lateinit var identifyPhone: EditText
 
-    private fun initializeSnapyr() {
-        if (snapyrInitialized) {
-            Toast.makeText(this, "Snapyr already initialized; restart app to initialize again", Toast.LENGTH_LONG).show()
-            return
+    private fun doIdentify() {
+        if (identifyUserId.text.toString() != snapyrData.identifyUserId) {
+            SnapyrComponent.instance.onDoReset()
         }
 
         snapyrData.identifyUserId = identifyUserId.text.toString()
         snapyrData.identifyEmail = identifyEmail.text.toString()
-        snapyrData.identifyKey = identifyKey.text.toString()
         snapyrData.identifyName = identifyName.text.toString()
         snapyrData.identifyPhone = identifyPhone.text.toString()
 
-        var snapyrHelper = SnapyrComponent.build(this.applicationContext)
-        // replay events to ensure Snapyr is aware of this activity (needed because we're late-initializing Snapyr from the Activity - normally it would be done on main app startup and would catch this activity automatically)
-        Snapyr.with(this).replayLifecycleOnActivityCreated(this, null)
-        Snapyr.with(this).replayLifecycleOnActivityStarted(this)
-        Snapyr.with(this).replayLifecycleOnActivityResumed(this)
-
-        snapyrHelper.onDoReset()
-        snapyrHelper.onDoIdentify()
-
-        snapyrHelper.registerInAppListener("splash", this)
-
-        snapyrInitialized = true
-
-        // disable inputs now that we've initialized
-        identifyUserId.isEnabled = false
-        identifyKey.isEnabled = false
-        identifyEmail.isEnabled = false
-        identifyName.isEnabled = false
-        identifyPhone.isEnabled = false
-        env.isEnabled = false
-        initSnapyrButton.isEnabled = false
+        SnapyrComponent.instance.onDoIdentify()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
 
-        identifyUserId = findViewById<EditText>(R.id.identify_userid);
-        identifyUserId.setText(snapyrData.identifyUserId)
+        SnapyrComponent.instance.registerInAppListener("splash", this)
 
         identifyKey = findViewById<EditText>(R.id.identify_key);
-        identifyKey.setText(snapyrData.identifyKey)
+        identifyUserId = findViewById<EditText>(R.id.identify_userid);
+
+        identifyKey.setText(snapyrData.sdkWriteKey)
+        identifyUserId.setText(snapyrData.identifyUserId)
 
         identifyEmail = findViewById<EditText>(R.id.identify_email);
         identifyEmail.setText(snapyrData.identifyEmail)
@@ -106,39 +89,18 @@ class SplashActivity : DebugActivityBase(), InAppCallback {
         identifyPhone = findViewById<EditText>(R.id.identify_phone);
         identifyPhone.setText(snapyrData.identifyPhone);
 
-        env.text = "Env: " + snapyrData.env
+        current_env.setText("ENV: " + snapyrData.env)
 
-        initSnapyrButton.setOnClickListener {
-            initializeSnapyr()
+        doIdentifyButton.setOnClickListener {
+            this.doIdentify()
         }
 
         playButton.setOnClickListener {
-            if (!snapyrInitialized) {
-                initializeSnapyr()
-            }
             IntentNavigator.startMainActivity(this)
         }
 
-        env.setOnClickListener{
-            val builder = AlertDialog.Builder(this)
-                .setTitle("Choose Env!")
-            builder.setPositiveButton("dev") { dialog, which ->
-                snapyrData.env = "dev"
-                identifyKey.setText("38bT1SbGJ0A12CJqk8DFRzypJnIylRmg")
-                env.text = "Env: dev"
-
-            }
-            builder.setNeutralButton("prod") { dialog, which ->
-                snapyrData.env = "prod"
-                identifyKey.setText("HheJr6JJGowjvMvJGq9FqunE0h8EKAIG")
-                env.text = "Env: prod"
-            }
-            builder.setNegativeButton("stg") { dialog, which ->
-                snapyrData.env = "stg"
-                identifyKey.setText("kuxCvTgQdcXAgNjrhrMP2U46VIhUi6Wz")
-                env.text = "Env: stg"
-            }
-            builder.show()
+        changeEnvOrKey.setOnClickListener{
+            onChangeEnvOrKey()
         }
 
         playerStinksButton.setOnClickListener {
@@ -166,6 +128,87 @@ class SplashActivity : DebugActivityBase(), InAppCallback {
         }
 
         setupWebView()
+    }
+
+    private fun onChangeEnvOrKey() {
+        val alertView = layoutInflater.inflate(R.layout.alert_writekey_env, null)
+        // Multiple dialog opens reuse the same inflated view - it needs to be removed from its parent before subsequent display or it will crash
+        if (alertView.parent != null) {
+            (alertView.parent as ViewGroup).removeView(alertView)
+        }
+
+        val writeKeyInput = alertView.findViewById<EditText>(R.id.alert_sdk_writekey)
+        val envLabel = alertView.findViewById<TextView>(R.id.alert_env)
+        val devButton = alertView.findViewById<Button>(R.id.alert_env_dev)
+        val stageButton = alertView.findViewById<Button>(R.id.alert_env_stage)
+        val prodButton = alertView.findViewById<Button>(R.id.alert_env_prod)
+        var selectedEnv = snapyrData.env
+
+        writeKeyInput.setText(snapyrData.sdkWriteKey)
+        envLabel.text = "Env: " + selectedEnv
+
+        devButton.setOnClickListener {
+            selectedEnv = "dev"
+            writeKeyInput.setText("MsZEepxHLRM9d7CU0ClTC84T0E9w9H8w")
+            envLabel.text = "Env: dev"
+        }
+        stageButton.setOnClickListener {
+            selectedEnv = "stg"
+            writeKeyInput.setText("kuxCvTgQdcXAgNjrhrMP2U46VIhUi6Wz")
+            envLabel.text = "Env: stg"
+        }
+        prodButton.setOnClickListener {
+            selectedEnv = "prod"
+            writeKeyInput.setText("HheJr6JJGowjvMvJGq9FqunE0h8EKAIG")
+            envLabel.text = "Env: prod"
+        }
+
+        val builder = AlertDialog.Builder(this)
+            .setTitle("SDK Write Key and Environment")
+        builder.setView(alertView)
+
+        builder.setPositiveButton(android.R.string.ok) { dialog, which ->
+            val isChanged = (selectedEnv != snapyrData.env || writeKeyInput.text.toString() != snapyrData.sdkWriteKey)
+            if (!isChanged) {
+                return@setPositiveButton
+            }
+            snapyrData.needsReset = true
+            snapyrData.env = selectedEnv
+            changeEnvOrKey.text = "Env: " + selectedEnv
+            snapyrData.sdkWriteKey = writeKeyInput.text.toString()
+            identifyKey.setText(writeKeyInput.text.toString())
+            showRestartRequiredAlert()
+        }
+        .setNegativeButton(android.R.string.cancel) { _, _ -> }
+
+        val dialog = builder.create()
+        // Make the dialog full screen width
+        val layoutParams = WindowManager.LayoutParams()
+        layoutParams.copyFrom(dialog.window!!.attributes)
+        layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT
+        layoutParams.height = WindowManager.LayoutParams.WRAP_CONTENT
+        dialog.show()
+        dialog.window!!.attributes = layoutParams
+    }
+
+    private fun showRestartRequiredAlert() {
+        AlertDialog.Builder(this)
+            .setTitle("Restart Snappy Bird to apply changes")
+            .setMessage("Your settings will be applied the next time you run the app. Please force quit and restart Snappy Bird.")
+            .setPositiveButton("Restart now") { _, _ ->
+                triggerRestart()
+            }
+            .setOnDismissListener {
+                triggerRestart()
+            }
+            .show()
+    }
+
+    fun triggerRestart() {
+        // Force restart of the app, back to this activity
+        val intent = Intent(applicationContext, this.javaClass)
+        this.startActivity(intent)
+        Runtime.getRuntime().exit(0)
     }
 
     @SuppressLint("ClickableViewAccessibility")

--- a/app/src/com/snapyr/flappybird/SplashActivity.kt
+++ b/app/src/com/snapyr/flappybird/SplashActivity.kt
@@ -65,6 +65,11 @@ class SplashActivity : DebugActivityBase(), InAppCallback {
         snapyrData.identifyPhone = identifyPhone.text.toString()
 
         var snapyrHelper = SnapyrComponent.build(this.applicationContext)
+        // replay events to ensure Snapyr is aware of this activity (needed because we're late-initializing Snapyr from the Activity - normally it would be done on main app startup and would catch this activity automatically)
+        Snapyr.with(this).replayLifecycleOnActivityCreated(this, null)
+        Snapyr.with(this).replayLifecycleOnActivityStarted(this)
+        Snapyr.with(this).replayLifecycleOnActivityResumed(this)
+
         snapyrHelper.onDoReset()
         snapyrHelper.onDoIdentify()
 


### PR DESCRIPTION
## Multiple activities and deeplink testing 

Adds additional activities with intent filters configured for deep link testing, and additional test event buttons on the Splash screen to trigger notifications with different deep links.

Allows testing of notifications with:
* deeplink that launches a standard activity
* deeplink that launches a singleTask activity
* invalid deeplink (does not match any intent filters) - should fall back to just opening the app, or bringing it to the foreground if it was already open
* no deeplink - should open the app, or bring it to the foreground if it was already open

## Init SDK on app start, restart to change key/env

Brings SDK init logic more in line w/ iOS flappy birds app and is closer to how real apps are supposed to use Snapyr SDK.

The SDK is initialized on app start using stashed write key and env. Splash screen allows changing these, but requires an app restart to apply (so they're applied on the next launch).

This also ensures that the SDK is live regardless of which activity was launched