### PR TITLE
Invalid json crash fix

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -13,7 +13,10 @@
         tools:ignore="GoogleAppIndexingWarning"
         android:name=".MyApp"
         >
-        <activity android:exported="true" android:name="com.snapyr.flappybird.SplashActivity">
+        <activity
+            android:exported="true"
+            android:name="com.snapyr.flappybird.SplashActivity"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -25,6 +28,7 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="com.snapyr.sdk.notifications.ACTION_DEEPLINK" />

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowFullscreen">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This app expects a particular format of JSON message, and was crashing if it received a message that was missing the expected keys or had the wrong data types.

Add some safety around this and alert the user if the message is in an unexpected format.

Also updates the app to be full screen only for the graphical game, so the status bar (with notification info) can be seen on non-game activities.